### PR TITLE
Fix: Only first transformer used sometimes

### DIFF
--- a/jarmon/jarmon.js
+++ b/jarmon/jarmon.js
@@ -722,11 +722,13 @@ jarmon.Chart.prototype.setup = function() {
         var unit = recipe.data[j][3];
         var transformer = recipe.data[j][4];
 
-        if(typeof(dataDict[rrd]) === 'undefined') {
-            dataDict[rrd] = new jarmon.RrdQueryRemote(
+        var key = rrd + "_" + ds;
+
+        if(typeof(dataDict[key]) === 'undefined') {
+            dataDict[key] = new jarmon.RrdQueryRemote(
                 rrd, unit, this.downloader, transformer);
         }
-        this.addData(label, new jarmon.RrdQueryDsProxy(dataDict[rrd], ds));
+        this.addData(label, new jarmon.RrdQueryDsProxy(dataDict[key], ds));
     }
 };
 


### PR DESCRIPTION
Reason is, that an internal dictionary uses only the rrd path to
distinguish between entries. I appended the ds to the string. Example
would be using the load rrd file which has 'shortterm', 'midterm' and
'longterm'